### PR TITLE
Adding DOCKER env var default to "yes" to trigger logging to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN su - cowrie -c "\
 
 FROM debian:stretch-slim
 MAINTAINER Michel Oosterhof <michel@oosterhof.net>
+
+ENV DOCKER "yes"
+
 RUN groupadd -r -g 1000 cowrie && \
     useradd -r -u 1000 -d /cowrie -m -g cowrie cowrie
 


### PR DESCRIPTION
The Cowrie source supports sending logging to stdout by setting `DOCKER="yes"` in [bin/cowrie](https://github.com/micheloosterhof/cowrie/blob/bdae37efc1a56f096ca9a1eb60ed033a91612cfc/bin/cowrie#L70-L71).

This change sets that variable in the Dockerfile with an `ENV` line, so the resulting Cowrie Docker image logs to logs to stdout by default, as considered best practice.  This is also a step toward running the container image with a read-only filesystem.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>