### PR TITLE
Replace image key with build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ volumes:
 services:
   cowrie:
     restart: always
-    image: .
+    build:
+      context: .
+      dockerfile: Dockerfile
     ports:
       - "2222:2222"
       - "2223:2223"


### PR DESCRIPTION
Replace `image` key with `build`, using `context` and `dockerfile`. Fixes https://github.com/docker/compose/issues/5693.
I was unable to run `docker-compose up` without these changes using the following docker-compose related versions:

```
docker-compose version 1.23.2, build 1110ad01
docker-py version: 3.6.0
CPython version: 3.6.7
OpenSSL version: OpenSSL 1.1.0f  25 May 2017
```