### PR TITLE
Fix missing distutils in latest debian/ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,8 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
       libssl1.1 \
       libffi6 \
       procps \
-      python3 && \
+      python3 \
+      python3-distutils && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /usr/bin/python3 /usr/local/bin/python
 


### PR DESCRIPTION
Fix ModuleNotFoundError: No module named 'distutils.util'

https://askubuntu.com/questions/1239829/modulenotfounderror-no-module-named-distutils-util